### PR TITLE
Add 5-second skip forward/backward and test playback functionality.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,10 @@ MUSIC_FOLDER=\\path\\to\\your\\music
 # Use forward slashes (/) in the path
 # Example: /Users/your-username/path/to/your/music
 MUSIC_FOLDER=/path/to/your/music
+
+# Spotify Secrets:
+
+# Get your Spotify API keys from https://developer.spotify.com/dashboard/
+SPOTIPY_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+SPOTIPY_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxx
+REDIRECT_URI=http://localhost:3000

--- a/ethos/main.py
+++ b/ethos/main.py
@@ -47,10 +47,12 @@ def test_player():
             player.play(songs[0]) # Play the first song in the folder
             time.sleep(5) 
 
+            player.skip_forward(30)
+
             print("Testing volume controls...")
             player.set_volume(50)
             time.sleep(2)
-            
+            player.skip_backward(15)  
             current_time = TrackInfo.get_current_time(player)
             progress = TrackInfo.get_progress(player)
 

--- a/ethos/player.py
+++ b/ethos/player.py
@@ -8,7 +8,8 @@ class MusicPlayer:
     A music player class for managing audio playback.
 
     The MusicPlayer class provides functionalities for managing a library of audio
-    files, playing, pausing, resuming, stopping tracks, and adjusting volume.
+    files, playing, pausing, resuming, stopping tracks, and adjusting volume, skipping forward
+    and backwards.
     It integrates with the VLC media player for handling playback.
     """
     def __init__(self):
@@ -92,7 +93,50 @@ class MusicPlayer:
     def get_volume(self) -> int:
         """Get current volume"""
         return self.player.audio_get_volume()
-    
+        
+    def skip_forward(self, seconds: int = 5):
+        """
+        Skip forward by a specified number of seconds.
+        
+        Args:
+        - seconds (int): Number of seconds to skip forward. Default is 5.
+        """
+        if not self.current_track:
+            return
+        
+        current_time = self.player.get_time()
+        if current_time == -1:  # No media or error
+            return
+        
+        new_time = current_time + seconds * 1000 
+        
+        # Ensure ethos don't skip beyond the end of the track
+        media = self.player.get_media()
+        if media:
+            duration = media.get_duration()
+            if duration != -1:
+                new_time = min(new_time, duration)
+        
+        self.player.set_time(new_time)
+
+    def skip_backward(self, seconds: int = 5):
+        """
+        Skip backward by a specified number of seconds.
+        
+        Args:
+        - seconds (int): Number of seconds to skip backward. Default is 5.
+        """
+        if not self.current_track:
+            return
+        
+        current_time = self.player.get_time()
+        if current_time == -1:  # No media or error
+            return
+        
+        new_time = current_time - seconds * 1000  
+        new_time = max(new_time, 0)  # Ensure time doesn't go negative
+        
+        self.player.set_time(new_time) 
 
 
 class TrackInfo:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-yt-dlp==2024.12.23
+yt-dlp==2025.1.15
 python-vlc==3.0.21203
 shazamio==0.7.0
 spotipy==2.25.0


### PR DESCRIPTION
closes #14 

## Changes Made:

1. Added 5-second skip forward/backward controls. (can be set any sec, 5 is the default)
2. Updated the yt-dlp version in `requirements.txt`
3. Adeed Spotify API secrets template for `env.example`

## Test Results:
- [x] Skip forward 5 seconds
- [x] Skip backward 5 seconds
- [x] Skip both sides for any number of seconds
- [x] Online playback (YouTube)
- [x]  Offline playback (local files)
